### PR TITLE
fix: 修复 README 中损坏的 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,8 +408,8 @@ See the [Yororen UI Wiki](https://github.com/MeowLynxSea/yororen-ui/wiki) for gu
 
 ## Star History
 
-<a href="https://www.star-history.com/#MeowLynxSea/yororen-ui&type=date&legend=top-left">
-  <img src="https://api.star-history.com/svg?repos=MeowLynxSea/yororen-ui&type=date&legend=top-left" alt="Star History Chart">
+<a href="https://star-history.dera.page/#MeowLynxSea/yororen-ui&type=date&legend=top-left">
+  <img src="https://star-history.dera.page/svg?repos=MeowLynxSea/yororen-ui&type=date&legend=top-left" alt="Star History Chart">
 </a>
 
 ---

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -407,8 +407,8 @@ gpui = { package = "gpui-ce", version = "0.3" }
 
 ## Star History
 
-<a href="https://www.star-history.com/#MeowLynxSea/yororen-ui&type=date&legend=top-left">
-  <img src="https://api.star-history.com/svg?repos=MeowLynxSea/yororen-ui&type=date&legend=top-left" alt="Star History Chart">
+<a href="https://star-history.dera.page/#MeowLynxSea/yororen-ui&type=date&legend=top-left">
+  <img src="https://star-history.dera.page/svg?repos=MeowLynxSea/yororen-ui&type=date&legend=top-left" alt="Star History Chart">
 </a>
 
 ---


### PR DESCRIPTION
当前 README 中的 Star History 图表已经损坏，无法正常显示，原因是 GitHub 对 stargazer API 实施了限制，导致原有数据源不可用。

本次改动将 README.md 和 README_zh_CN.md 中的图表链接更新为可正常工作的数据源，该方案无需 API token 即可加载图表，保证图表能恢复展示。